### PR TITLE
Correction Durée prise dans le calcul du risque

### DIFF
--- a/mmassistant.user.js
+++ b/mmassistant.user.js
@@ -911,7 +911,8 @@ function initMatos() {
 			} else if(/[Z,z]one/.test(effet)) {
 				// Malus de Zone
 				objPopos[num].zone = 1;
-			} else {
+			} else if (carac!="Durée") {
+				// Ne pas prendre en compte la durée dans le risque de la potion
 				window.console.warn("[mmassistant] Effet inconnu:", effet);
 			}
 		}


### PR DESCRIPTION
Suite aux modifications d'affichage de Mountyhall, la durée de chaque potion est maintenant affichée.

Cette correction vise à ce que cette durée ne soit pas prise en compte dans le calcul du risque unitaire d'une potion.