### PR TITLE
Correction commit "Correction Duréprise dans le calcul du risque"

### DIFF
--- a/mmassistant.user.js
+++ b/mmassistant.user.js
@@ -909,14 +909,14 @@ function initMatos() {
 				} else if(carac.indexOf("Pàïntûré")!=-1) {
 					// Si Painture, malus = niv x 10
 					risque += nb*10;
-				} else {
+				} else if (carac!="Durée") {
+					// Ne pas prendre en compte la durée dans le risque de la potion
 					risque += Number(nb);
 				}
 			} else if(/[Z,z]one/.test(effet)) {
 				// Malus de Zone
 				objPopos[num].zone = 1;
-			} else if (carac!="Durée") {
-				// Ne pas prendre en compte la durée dans le risque de la potion
+			} else {
 				window.console.warn("[mmassistant] Effet inconnu:", effet);
 			}
 		}


### PR DESCRIPTION
Erreur lors de la première correction : test au mauvais endroit

Texte de la correction originale :
"Correction Durée prise dans le calcul du risque

Suite aux modifications d'affichage de Mountyhall, la durée de chaque potion est maintenant affichée.

Cette correction vise à ce que cette durée ne soit pas prise en compte dans le calcul du risque unitaire d'une potion."