### PR TITLE
Correction Durée pour "PufPuff"/"Elixir de Corruption"

### DIFF
--- a/mmassistant.user.js
+++ b/mmassistant.user.js
@@ -862,12 +862,12 @@ function initMatos() {
 				case "PufPuff":
 					// niveau = malus Vue
 					// Si malus PV, on ajoute "Tox."
-					niveau = effets.length>4 ?
+					niveau = effets.length>5 ?
 						"3 Tox." : effets[effets.length-2].match(/\d+/);
 					break;
 				case "Elixir de Corruption":
 					// niveau = niveau + MM/RM
-					if(effets.length>6) {
+					if(effets.length>7) {
 						niveau += " ("+
 							effets[6].match(/\d+/)+"/"+
 							effets[7].match(/\d+/)+")";


### PR DESCRIPTION
Suite aux modifications d'affichage de Mountyhall, la durée d'effet d'une potion est affichée
comme une caractéristique.
Pour la récupération des caractéristiques des potions "PufPuff" et "Elixir de Corruption",
dont le nombre est variable selon le niveau,
doit être adapté :
- "PuffPuff" peut avoir un malus de PV (6 caractéristiques) ou non (5 caractéristiques).
- "Elixir de Corruption" peut avoir des bonus/malus de RM/MM (9 caractéristiques)
ou non (7 caractéristiques).